### PR TITLE
Fix Moodle 2.7 compatibility notices

### DIFF
--- a/recorders/flashaudiorecorder/lib.php
+++ b/recorders/flashaudiorecorder/lib.php
@@ -73,8 +73,11 @@ class repository_mediacapture_flashaudiorecorder extends recorder {
                     </object>';
         $mform->addElement('html', $recorder);
         $mform->addElement('hidden', 'filepath', '');
+        $mform->setType('filepath', PARAM_PATH);
         $mform->addElement('hidden', 'filename', '');
+        $mform->setType('filename', PARAM_FILE);
         $mform->addElement('hidden', 'filetype', $this->supported_filetype());
+        $mform->setType('filetype', PARAM_FILE);
     }
 
     /**

--- a/recorders/nanogong/lib.php
+++ b/recorders/nanogong/lib.php
@@ -94,8 +94,11 @@ class repository_mediacapture_nanogong extends recorder {
                     </applet>';
         $mform->addElement('html', $recorder);
         $mform->addElement('hidden', 'filepath', '');
+        $mform->setType('filepath', PARAM_PATH);
         $mform->addElement('hidden', 'filetype', $this->supported_filetype());
+        $mform->setType('filetype', PARAM_FILE);
         $mform->addElement('text', 'filename', get_string('name', 'repository_mediacapture'));
+        $mform->setType('filename', PARAM_FILE);
         $mform->addElement('submit', 'save', get_string('save', 'repository_mediacapture'));
     }
 

--- a/recorders/red5recorder/lib.php
+++ b/recorders/red5recorder/lib.php
@@ -89,9 +89,13 @@ class repository_mediacapture_red5recorder extends recorder {
                     </object>';
         $mform->addElement('html', $recorder);
         $mform->addElement('hidden', 'filepath', urlencode($streampath));
+        $mform->setType('filepath', PARAM_PATH);
         $mform->addElement('hidden', 'filetype', $this->supported_filetype());
+        $mform->setType('filetype', PARAM_FILE);
         $mform->addElement('hidden', 'tmpname', $tmpname);
+        $mform->setType('tmpname', PARAM_FILE);
         $mform->addElement('text', 'filename', get_string('name', 'repository_mediacapture'));
+        $mform->setType('filename', PARAM_FILE);
         $mform->addElement('submit', 'save', get_string('save', 'repository_mediacapture'));
     }
 

--- a/view.php
+++ b/view.php
@@ -33,7 +33,7 @@ $browserdetect  = optional_param('browserdetect', '', PARAM_TEXT);
 $repositoryid   = required_param('repositoryid', PARAM_INT);
 $contextid      = required_param('contextid', PARAM_INT);
 
-$PAGE->set_context(get_context_instance(CONTEXT_SYSTEM));
+$PAGE->set_context(context_system::instance());
 $PAGE->set_url('/repository/mediacapture/view.php', array('returnurl'=>$returnurl));
 $PAGE->set_pagelayout('embedded');
 


### PR DESCRIPTION
Fixes notices shown in Moodle 2.7 with debugging enabled:

```
get_context_instance() is deprecated, please use context_xxxx::instance() instead.
line 3670 of /lib/deprecatedlib.php: call to debugging()
line 36 of /repository/mediacapture/view.php: call to get_context_instance()
```

Also notices about type not set in MForms
